### PR TITLE
Fix bug not setting new spotify account as active

### DIFF
--- a/routes/auth/credentials.py
+++ b/routes/auth/credentials.py
@@ -129,6 +129,20 @@ async def handle_create_credential(service: str, name: str, request: Request, cu
         # For Deezer, it expects 'arl' and 'region'
         # Validation is handled within create_credential utility function
         result = create_credential(service, name, data)
+
+        # set as active Spotify account if none is set
+        if service == "spotify":
+            try:
+                from routes.utils.celery_config import get_config_params as get_main_config_params
+                from routes.system.config import save_config
+                config = get_main_config_params()
+                # The field is likely "spotify" (as used in frontend)
+                if not config.get("spotify"):
+                    config["spotify"] = name
+                    save_config(config)
+            except Exception as e:
+                logger.warning(f"Could not set new Spotify account '{name}' as active: {e}")
+
         return {
             "message": f"Credential for '{name}' ({service}) created successfully.",
             "details": result,

--- a/spotizerr-ui/src/components/config/AccountsTab.tsx
+++ b/spotizerr-ui/src/components/config/AccountsTab.tsx
@@ -85,6 +85,7 @@ export function AccountsTab() {
     onSuccess: () => {
       toast.success("Account added successfully!");
       queryClient.invalidateQueries({ queryKey: ["credentials", activeService] });
+      queryClient.invalidateQueries({ queryKey: ["config"] }); // Invalidate config to update active Spotify account in UI
       setIsAdding(false);
       setSubmitError(null);
       reset();


### PR DESCRIPTION
When adding a new account it's not active, resulting in error:

```[spotizerr] | 2025-08-21 18:28:41 [INFO] Celery[DW-STDERR]: File "/app/routes/utils/track.py", line 202, in download_track
[spotizerr] | 2025-08-21 18:28:41 [INFO] Celery[DW-STDERR]: raise FileNotFoundError(
[spotizerr] | 2025-08-21 18:28:41 [INFO] Celery[DW-STDERR]: FileNotFoundError: Spotify credentials blob file not found at data/creds/blobs/credentials.json for account ''
[spotizerr] | 2025-08-21 18:28:41 [INFO] Celery[DW-STDERR]: Task 314182ae-c8c0-4d54-9054-24d153f5c935 failed: Spotify credentials blob file not found at data/creds/blobs/credentials.json for account ''
[spotizerr] | 2025-08-21 18:28:41 [INFO] Celery[DW-STDERR]: Task 314182ae-c8c0-4d54-9054-24d153f5c935 can be retried (0/3)
[spotizerr] | 2025-08-21 18:28:41 [INFO] Celery[UW-STDERR]: Task trigger_sse_update_task[7f156194-f469-4f13-a043-0848d4996dc6] received
[spotizerr] | 2025-08-21 18:28:41 [INFO] Celery[DW-STDERR]: Task download_track[314182ae-c8c0-4d54-9054-24d153f5c935] raised unexpected: FileNotFoundError("Spotify credentials blob file not found at data/creds/blobs/credentials.json for account ''")```