### PR TITLE
(feat): introduce a global rate limiter, showing consumption to user

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,6 +64,7 @@ from routes.core.search import router as search_router
 from routes.core.history import router as history_router
 from routes.system.progress import router as prgs_router
 from routes.system.config import router as config_router
+from routes.system.rate_limit import router as rate_limit_router
 
 
 # Import Celery configuration and manager
@@ -330,6 +331,7 @@ def create_app():
     app.include_router(artist_router, prefix="/api/artist", tags=["artist"])
     app.include_router(prgs_router, prefix="/api/prgs", tags=["progress"])
     app.include_router(history_router, prefix="/api/history", tags=["history"])
+    app.include_router(rate_limit_router, prefix="/api/rate-limit", tags=["rate-limit"])
 
     # Add request logging middleware
     @app.middleware("http")

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ import sys
 import redis
 import socket
 from urllib.parse import urlparse
+import deezspot
 
 # Define a mapping from string log levels to logging constants
 LOG_LEVELS = {
@@ -145,6 +146,9 @@ def setup_logging():
         # For uvicorn.access, we explicitly set propagate to False to prevent duplicate logging
         # if access_log=False is used in uvicorn.run, and to ensure our middleware handles it.
         logger.propagate = False if logger_name == "uvicorn.access" else True
+
+    # Configure deezspot logger using its provided function
+    deezspot.set_log_level(logging.DEBUG)
 
     logging.info("Logging system initialized")
 

--- a/app.py
+++ b/app.py
@@ -141,15 +141,13 @@ def setup_logging():
         "uvicorn",          # General Uvicorn logger
         "uvicorn.access",   # Uvicorn access logs
         "uvicorn.error",    # Uvicorn error logs
+        "deezspot"          # Deezspot logs
     ]:
         logger = logging.getLogger(logger_name)
         logger.setLevel(log_level)
         # For uvicorn.access, we explicitly set propagate to False to prevent duplicate logging
         # if access_log=False is used in uvicorn.run, and to ensure our middleware handles it.
         logger.propagate = False if logger_name == "uvicorn.access" else True
-
-    # Configure deezspot logger using its provided function
-    deezspot.set_log_level(logging.DEBUG)
 
     logging.info("Logging system initialized")
 

--- a/routes/auth/credentials.py
+++ b/routes/auth/credentials.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Request, Depends
 import json
 import logging
+from typing import Dict, Union, Any
 from routes.utils.credentials import (
     get_credential,
     list_credentials,
@@ -41,7 +42,7 @@ def _set_active_account_if_empty(service: str, name: str):
 
 @router.get("/spotify_api_config")
 @router.put("/spotify_api_config")
-async def handle_spotify_api_config(request: Request, current_user: User = Depends(require_admin_from_state)):
+async def handle_spotify_api_config(request: Request, current_user: User = Depends(require_admin_from_state)) -> Dict[str, Union[str, None]]:
     """Handles GET and PUT requests for the global Spotify API client_id and client_secret."""
     try:
         if request.method == "GET":
@@ -63,6 +64,8 @@ async def handle_spotify_api_config(request: Request, current_user: User = Depen
                     status_code=400,
                     detail={"error": "Request body must contain 'client_id' and 'client_secret'"}
                 )
+        else:
+            raise HTTPException(status_code=405, detail={"error": "Method Not Allowed"})
 
             client_id = data["client_id"]
             client_secret = data["client_secret"]
@@ -86,6 +89,7 @@ async def handle_spotify_api_config(request: Request, current_user: User = Depen
     except Exception as e:
         logger.error(f"Error in /spotify_api_config: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail={"error": f"An unexpected error occurred: {str(e)}"})
+    return {"client_id": None, "client_secret": None} # Should be unreachable, but satisfies type checker
 
 
 @router.get("/{service}")

--- a/routes/system/rate_limit.py
+++ b/routes/system/rate_limit.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends, HTTPException
+from routes.utils.redis_rate_limiter import global_rate_limiter
+import logging
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+@router.get("/current", response_model=dict, summary="Get current rate limit usage")
+async def get_current_rate_limit_usage():
+    """
+    Returns the current rate limit consumption
+    """
+    try:
+        usage = global_rate_limiter.get_current_usage()
+        return usage
+    except Exception as e:
+        logger.error(f"Error getting current rate limit usage: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/routes/utils/album.py
+++ b/routes/utils/album.py
@@ -1,4 +1,5 @@
 import traceback
+from typing import Optional
 from deezspot.spotloader import SpoLogin
 from deezspot.deezloader import DeeLogin
 from routes.utils.credentials import (
@@ -31,8 +32,8 @@ def download_album(
     recursive_quality=True,
     spotify_metadata=True,
     _is_celery_task_execution=False,  # Added to skip duplicate check from Celery task
-    real_time_multiplier=None,
-    pad_number_width=None,
+    real_time_multiplier: Optional[int] = None,
+    pad_number_width: Optional[int] = None,
 ):
     if not _is_celery_task_execution:
         existing_task = get_existing_task_id(
@@ -44,6 +45,8 @@ def download_album(
                 existing_task=existing_task,
             )
     try:
+        _pad_number_width = int(pad_number_width) if pad_number_width is not None else 0
+        _real_time_multiplier = int(real_time_multiplier) if real_time_multiplier is not None else 0
         # Detect URL source (Spotify or Deezer) from URL
         is_spotify_url = "open.spotify.com" in url.lower()
         is_deezer_url = "deezer.com" in url.lower()
@@ -118,7 +121,7 @@ def download_album(
                         bitrate=bitrate,
                         artist_separator=artist_separator,
                         spotify_metadata=spotify_metadata,
-                        pad_number_width=pad_number_width,
+                        pad_number_width=_pad_number_width,
                     )
                     print(
                         f"DEBUG: album.py - Album download via Deezer (account: {fallback}) successful for Spotify URL."
@@ -176,8 +179,8 @@ def download_album(
                             convert_to=convert_to,
                             bitrate=bitrate,
                             artist_separator=artist_separator,
-                            real_time_multiplier=real_time_multiplier,
-                            pad_number_width=pad_number_width,
+                            real_time_multiplier=_real_time_multiplier,
+                            pad_number_width=_pad_number_width,
                         )
                         print(
                             f"DEBUG: album.py - Spotify direct download (account: {main} for blob) successful."
@@ -233,8 +236,8 @@ def download_album(
                     convert_to=convert_to,
                     bitrate=bitrate,
                     artist_separator=artist_separator,
-                    real_time_multiplier=real_time_multiplier,
-                    pad_number_width=pad_number_width,
+                    real_time_multiplier=_real_time_multiplier,
+                    pad_number_width=_pad_number_width,
                 )
                 print(
                     f"DEBUG: album.py - Direct Spotify download (account: {main} for blob) successful."
@@ -275,7 +278,7 @@ def download_album(
                 convert_to=convert_to,
                 bitrate=bitrate,
                 artist_separator=artist_separator,
-                pad_number_width=pad_number_width,
+                pad_number_width=_pad_number_width,
             )
             print(
                 f"DEBUG: album.py - Direct Deezer download (account: {main}) successful."

--- a/routes/utils/album.py
+++ b/routes/utils/album.py
@@ -9,8 +9,10 @@ from routes.utils.credentials import (
 )
 from routes.utils.celery_queue_manager import get_existing_task_id
 from routes.utils.errors import DuplicateDownloadError
+from routes.utils.redis_rate_limiter import global_rate_limiter
 
 
+@global_rate_limiter.rate_limit_decorator
 def download_album(
     url,
     main,

--- a/routes/utils/celery_tasks.py
+++ b/routes/utils/celery_tasks.py
@@ -349,7 +349,7 @@ def get_task_status(task_id):
     """Get all task status updates from Redis"""
     try:
         status_list = redis_client.lrange(f"task:{task_id}:status", 0, -1)
-        return [json.loads(s.decode("utf-8")) for s in status_list]
+        return [json.loads(s.decode("utf-8")) for s in status_list] # type: ignore
     except Exception as e:
         logger.error(f"Error getting task status: {e}")
         return []
@@ -363,7 +363,7 @@ def get_last_task_status(task_id):
         if not status_list:
             return None
 
-        return json.loads(status_list[0].decode("utf-8"))
+        return json.loads(status_list[0].decode("utf-8")) # type: ignore
     except Exception as e:
         logger.error(f"Error getting last task status: {e}")
         return None
@@ -383,7 +383,7 @@ def get_task_info(task_id):
     try:
         task_info = redis_client.get(f"task:{task_id}:info")
         if task_info:
-            return json.loads(task_info.decode("utf-8"))
+            return json.loads(task_info.decode("utf-8")) # type: ignore
         return {}
     except Exception as e:
         logger.error(f"Error getting task info: {e}")
@@ -1253,6 +1253,9 @@ class ProgressTrackingTask(Task):
 @task_prerun.connect
 def task_prerun_handler(task_id=None, task=None, *args, **kwargs):
     """Signal handler when a task begins running"""
+    if task_id is None:
+        logger.error("task_prerun_handler received None for task_id. Skipping.")
+        return
     try:
         # Skip verbose logging for SSE tasks
         if task and hasattr(task, "name") and task.name in ["trigger_sse_update_task"]:
@@ -1284,6 +1287,9 @@ def task_postrun_handler(
     task_id=None, task=None, retval=None, state=None, *args, **kwargs
 ):
     """Signal handler when a task finishes"""
+    if task_id is None:
+        logger.error("task_postrun_handler received None for task_id. Skipping.")
+        return
     try:
         # Skip verbose logging for SSE tasks
         if task and hasattr(task, "name") and task.name in ["trigger_sse_update_task"]:
@@ -1977,7 +1983,7 @@ def cleanup_stale_errors():
         current_time = time.time()
         stale_threshold = 60  # 1 minute
 
-        for key_bytes in task_keys:
+        for key_bytes in task_keys: # type: ignore
             task_id = key_bytes.decode("utf-8").split(":")[1]
             last_status = get_last_task_status(task_id)
 

--- a/routes/utils/playlist.py
+++ b/routes/utils/playlist.py
@@ -40,6 +40,18 @@ def download_playlist(
                 "Download for this URL is already in progress.",
                 existing_task=existing_task,
             )
+
+    # Ensure pad_number_width is an integer if provided, otherwise default to 0
+    if pad_number_width is None:
+        pad_number_width = 0
+    elif not isinstance(pad_number_width, (int, str)):
+        pass # Keep existing logic for other types
+
+    # Ensure real_time_multiplier is an integer if provided, otherwise default to 1
+    if real_time_multiplier is None:
+        real_time_multiplier = 1
+    elif not isinstance(real_time_multiplier, int):
+        pass # Keep existing logic for other types
     try:
         # Detect URL source (Spotify or Deezer) from URL
         is_spotify_url = "open.spotify.com" in url.lower()

--- a/routes/utils/playlist.py
+++ b/routes/utils/playlist.py
@@ -5,8 +5,10 @@ from pathlib import Path
 from routes.utils.credentials import get_credential, _get_global_spotify_api_creds
 from routes.utils.celery_queue_manager import get_existing_task_id
 from routes.utils.errors import DuplicateDownloadError
+from routes.utils.redis_rate_limiter import global_rate_limiter
 
 
+@global_rate_limiter.rate_limit_decorator
 def download_playlist(
     url,
     main,

--- a/routes/utils/redis_rate_limiter.py
+++ b/routes/utils/redis_rate_limiter.py
@@ -1,0 +1,230 @@
+import time
+import redis
+import logging
+import random
+import re
+from functools import wraps
+import threading
+from typing import Callable, Any
+from routes.utils.celery_config import REDIS_URL
+
+logger = logging.getLogger(__name__)
+
+class RedisRateLimiter:
+    """
+    Redis-backed rate limiter supporting both per-second and sliding window limits.
+    """
+
+    def __init__(
+        self,
+        redis_client: redis.Redis,
+        key_prefix: str = "api_rate_limit",
+        max_requests_per_window: int = 90,
+        window_size_seconds: int = 30,
+        max_requests_per_second: int = 10,
+        per_second_window: int = 1,
+        usage_logger: bool = False,
+        retry_attempts: int = 3,
+        base_delay: float = 1.0,
+    ):
+        self.redis_client = redis_client
+        self.key_timestamps = f"{key_prefix}:timestamps"
+        self.key_retry_after_until = f"{key_prefix}:retry_after_until"
+        self.max_requests_per_window = max_requests_per_window
+        self.window_size_seconds = window_size_seconds
+        self.max_requests_per_second = max_requests_per_second
+        self.per_second_window = per_second_window
+        self.retry_attempts = retry_attempts
+        self.base_delay = base_delay
+
+        # Cleanup Redis keys on startup
+        self._cleanup_keys_on_startup()
+
+        if usage_logger:
+            self._start_usage_logger()
+
+    def _zcard(self, key: str) -> int:
+        """Return the cardinality of the sorted set as int."""
+        # Pylance may think this is Awaitable, but for sync redis-py this is int.
+        return int(self.redis_client.zcard(key))  # type: ignore
+
+    def _cleanup_old_timestamps(self, current_time: float) -> None:
+        """Remove old timestamps outside the sliding window using a pipeline for efficiency."""
+        pipe = self.redis_client.pipeline()
+        pipe.zremrangebyscore(self.key_timestamps, 0, current_time - self.window_size_seconds)
+        pipe.execute()
+
+    def _cleanup_keys_on_startup(self) -> None:
+        """Cleanup all Redis keys with the same prefix on startup to prevent stale data accumulation."""
+        try:
+            # Delete both keys if they exist
+            self.redis_client.delete(self.key_timestamps, self.key_retry_after_until)
+            logger.info(f"Cleaned up Redis keys: {self.key_timestamps}, {self.key_retry_after_until}")
+        except Exception as e:
+            logger.warning(f"Failed to cleanup Redis keys on startup: {e}")
+
+    def get_current_usage(self) -> dict:
+        """
+        Returns the current rate limit consumption.
+        """
+        current_time = time.time()
+        self._cleanup_old_timestamps(current_time)
+        current_requests_per_second = int(self.redis_client.zcount(self.key_timestamps, current_time - self.per_second_window, current_time))  # type: ignore
+        current_requests_per_window = self._zcard(self.key_timestamps)
+        return {
+            "current_requests_per_second": current_requests_per_second,
+            "max_requests_per_second": self.max_requests_per_second,
+            "current_requests_per_window": current_requests_per_window,
+            "max_requests_per_window": self.max_requests_per_window,
+            "window_size_seconds": self.window_size_seconds,
+        }
+
+    def _start_usage_logger(self) -> None:
+        """
+        Starts a background thread that logs the current rate limit usage every second.
+        For debugging purposes only.
+        """
+        def log_usage():
+            while True:
+                try:
+                    usage = self.get_current_usage()
+                    logger.debug(
+                        f"Rate limit usage: "
+                        f"{usage['current_requests_per_second']}/{usage['max_requests_per_second']} req/s, "
+                        f"{usage['current_requests_per_window']}/{usage['max_requests_per_window']} req/{usage['window_size_seconds']}s"
+                    )
+                except Exception as e:
+                    logger.error(f"Error logging rate limit usage: {e}")
+                time.sleep(1)
+        t = threading.Thread(target=log_usage, daemon=True)
+        t.start()
+
+    def _get_retry_after_until(self) -> float:
+        val = self.redis_client.get(self.key_retry_after_until)
+        # Pylance may think this is Awaitable, but for sync redis-py this is bytes.
+        return float(val.decode('utf-8')) if val else 0.0  # type: ignore
+
+    def _set_retry_after_until(self, timestamp: float) -> None:
+        self.redis_client.set(self.key_retry_after_until, str(timestamp))
+        # Set expiration for the retry_after_until key to prevent stale data accumulation
+        # Expire after window_size_seconds + 60 seconds buffer
+        self.redis_client.expire(self.key_retry_after_until, self.window_size_seconds + 60)
+
+    def _check_and_handle_retry_after(self) -> bool:
+        """
+        Check if there's a retry-after in effect and handle it if needed.
+        Returns True if we need to retry, False otherwise.
+        """
+        retry_after_until = self._get_retry_after_until()
+        now = time.time()
+        if now < retry_after_until:
+            sleep_duration = retry_after_until - now
+            logger.warning(f"Rate limiter active: Respecting Retry-After. Delaying task for {sleep_duration:.2f} seconds.")
+            time.sleep(sleep_duration)
+            return True  # Need to retry
+        return False  # No retry-after in effect
+    
+    def _check_limit_and_wait(
+        self,
+        current_requests: int,
+        max_requests: int,
+        window_size: int,
+        limit_type: str
+    ) -> bool:
+        """
+        Check if a limit is exceeded and wait if needed.
+        Returns True if we need to retry, False otherwise.
+        """
+        if current_requests >= max_requests:
+            oldest = self.redis_client.zrange(self.key_timestamps, 0, 0, withscores=True)
+            if oldest:
+                # Pylance may think this is Awaitable, but for sync redis-py this is a list of tuples.
+                now = time.time()
+                time_to_wait = oldest[0][1] + window_size - now  # type: ignore
+                if time_to_wait > 0:
+                    logger.warning(f"Rate limiter active: {limit_type} limit ({max_requests}) reached. Delaying for {time_to_wait:.2f} seconds.")
+                    time.sleep(time_to_wait)
+                    return True  # Need to retry
+        return False  # No need to retry
+    
+    def _wait_for_rate_limit(self, current_time: float) -> None:
+        """
+        Handles the waiting logic for rate limiting, including respecting Retry-After
+        and proactive sliding window limits. Ensures atomicity using Redis transactions.
+        """
+        for attempt in range(self.retry_attempts):
+            # Check and handle retry-after first
+            if self._check_and_handle_retry_after():
+                continue  # Re-check after handling retry-after
+
+            # Use pipeline for atomicity and efficiency
+            now = time.time()
+            pipe = self.redis_client.pipeline()
+            # Remove old timestamps outside sliding window
+            pipe.zremrangebyscore(self.key_timestamps, 0, now - self.window_size_seconds)
+            # Get per-second count
+            pipe.zcount(self.key_timestamps, now - self.per_second_window, now)
+            # Get sliding window count
+            pipe.zcard(self.key_timestamps)
+            results = pipe.execute()
+            current_requests_per_second = int(results[1])
+            current_requests_per_window = int(results[2])
+
+            # Check per-second burst limit
+            if self._check_limit_and_wait(
+                current_requests_per_second,
+                self.max_requests_per_second,
+                self.per_second_window,
+                "Per-second"
+            ):
+                continue  # Re-check after waiting
+
+            # Check sliding window limit
+            if self._check_limit_and_wait(
+                current_requests_per_window,
+                self.max_requests_per_window,
+                self.window_size_seconds,
+                "Window"
+            ):
+                continue  # Re-check after waiting
+
+            # If within limits, record the request timestamp (with unique member)
+            member = f"{now}-{random.random()}"
+            self.redis_client.zadd(self.key_timestamps, {member: now})
+            return  # Allowed
+
+        raise Exception("Rate limit exceeded after multiple retries.")
+
+    def rate_limit_decorator(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        """
+        Decorator to apply rate limiting to a function.
+        """
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            for attempt in range(self.retry_attempts):
+                try:
+                    self._wait_for_rate_limit(time.time())
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    msg = str(e).lower()
+                    if "429" in msg or "rate limit" in msg:
+                        retry_after_match = re.search(r"retry-after: (\d+)", str(e), re.IGNORECASE)
+                        if retry_after_match:
+                            retry_after_seconds = int(retry_after_match.group(1))
+                            logger.warning(f"API Rate limited, respecting Retry-After: {retry_after_seconds} seconds.")
+                            self._set_retry_after_until(time.time() + retry_after_seconds)
+                        else:
+                            jitter = random.uniform(0, 1)
+                            delay = self.base_delay * (2 ** attempt) + jitter
+                            logger.warning(f"API Rate limited, retrying in {delay:.2f} seconds (with jitter)...")
+                            self._set_retry_after_until(time.time() + delay)
+                        if attempt < self.retry_attempts - 1:
+                            continue
+                    logger.error(f"Unexpected error during API call: {e}")
+                    raise
+            raise Exception("Rate limit exceeded after maximum retries.")
+        return wrapper
+
+# Initialize Redis client and global rate limiter instance
+redis_client = redis.Redis.from_url(REDIS_URL)
+global_rate_limiter = RedisRateLimiter(redis_client, usage_logger=True)

--- a/routes/utils/search.py
+++ b/routes/utils/search.py
@@ -2,7 +2,7 @@ import spotipy
 from spotipy.oauth2 import SpotifyClientCredentials
 import logging
 from routes.utils.credentials import get_credential, _get_global_spotify_api_creds
-from routes.utils.get_info import _rate_limit_handler
+from routes.utils.redis_rate_limiter import global_rate_limiter
 import time
 from typing import Optional, Any
 
@@ -47,7 +47,7 @@ def _get_spotify_client():
     
     return _spotify_client
 
-@_rate_limit_handler
+@global_rate_limiter.rate_limit_decorator
 def search(query: str, search_type: str, limit: int = 3, main: Optional[str] = None) -> Any:
     logger.info(
         f"Search requested: query='{query}', type={search_type}, limit={limit}, main_account_name={main}"

--- a/routes/utils/search.py
+++ b/routes/utils/search.py
@@ -2,7 +2,9 @@ import spotipy
 from spotipy.oauth2 import SpotifyClientCredentials
 import logging
 from routes.utils.credentials import get_credential, _get_global_spotify_api_creds
+from routes.utils.get_info import _rate_limit_handler
 import time
+from typing import Optional, Any
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -11,6 +13,7 @@ logger = logging.getLogger(__name__)
 _spotify_client = None
 _last_client_init = 0
 _client_init_interval = 3600  # Reinitialize client every hour
+
 
 def _get_spotify_client():
     """
@@ -44,7 +47,8 @@ def _get_spotify_client():
     
     return _spotify_client
 
-def search(query: str, search_type: str, limit: int = 3, main: str = None) -> dict:
+@_rate_limit_handler
+def search(query: str, search_type: str, limit: int = 3, main: Optional[str] = None) -> Any:
     logger.info(
         f"Search requested: query='{query}', type={search_type}, limit={limit}, main_account_name={main}"
         )
@@ -89,13 +93,16 @@ def search(query: str, search_type: str, limit: int = 3, main: str = None) -> di
         spotify_type = search_type_map.get(search_type.lower(), 'track')
         
         # Execute search using Spotipy
+        start_time = time.time()
         spotify_response = client.search(
             q=query,
             type=spotify_type,
             limit=limit
         )
+        end_time = time.time()
+        elapsed_time = end_time - start_time
         
-        logger.info(f"Search completed successfully for query: '{query}'")
+        logger.info(f"Search completed successfully for query: '{query}' in {elapsed_time:.2f} seconds")
         return spotify_response
     except Exception as e:
         logger.error(

--- a/routes/utils/track.py
+++ b/routes/utils/track.py
@@ -1,4 +1,5 @@
 import traceback
+from typing import Optional
 from deezspot.spotloader import SpoLogin
 from deezspot.deezloader import DeeLogin
 from routes.utils.credentials import (
@@ -29,10 +30,12 @@ def download_track(
     recursive_quality=False,
     spotify_metadata=True,
     _is_celery_task_execution=False,  # Added for consistency, not currently used for duplicate check
-    real_time_multiplier=None,
-    pad_number_width=None,
+    real_time_multiplier: Optional[int] = None,
+    pad_number_width: Optional[int] = None,
 ):
     try:
+        _pad_number_width = int(pad_number_width) if pad_number_width is not None else 0
+        _real_time_multiplier = int(real_time_multiplier) if real_time_multiplier is not None else 0
         # Detect URL source (Spotify or Deezer) from URL
         is_spotify_url = "open.spotify.com" in url.lower()
         is_deezer_url = "deezer.com" in url.lower()
@@ -109,7 +112,7 @@ def download_track(
                         bitrate=bitrate,
                         artist_separator=artist_separator,
                         spotify_metadata=spotify_metadata,
-                        pad_number_width=pad_number_width,
+                        pad_number_width=_pad_number_width,
                     )
                     print(
                         f"DEBUG: track.py - Track download via Deezer (account: {fallback}) successful for Spotify URL."
@@ -169,8 +172,7 @@ def download_track(
                             convert_to=convert_to,
                             bitrate=bitrate,
                             artist_separator=artist_separator,
-                            spotify_metadata=spotify_metadata,
-                            pad_number_width=pad_number_width,
+                            pad_number_width=_pad_number_width,
                         )
                         print(
                             f"DEBUG: track.py - Spotify direct download (account: {main} for blob) successful."
@@ -227,8 +229,8 @@ def download_track(
                     convert_to=convert_to,
                     bitrate=bitrate,
                     artist_separator=artist_separator,
-                    real_time_multiplier=real_time_multiplier,
-                    pad_number_width=pad_number_width,
+                    real_time_multiplier=_real_time_multiplier,
+                    pad_number_width=_pad_number_width,
                 )
                 print(
                     f"DEBUG: track.py - Direct Spotify download (account: {main} for blob) successful."
@@ -268,7 +270,7 @@ def download_track(
                 convert_to=convert_to,
                 bitrate=bitrate,
                 artist_separator=artist_separator,
-                pad_number_width=pad_number_width,
+                pad_number_width=_pad_number_width,
             )
             print(
                 f"DEBUG: track.py - Direct Deezer download (account: {main}) successful."

--- a/routes/utils/track.py
+++ b/routes/utils/track.py
@@ -7,8 +7,10 @@ from routes.utils.credentials import (
     _get_global_spotify_api_creds,
     get_spotify_blob_path,
 )
+from routes.utils.redis_rate_limiter import global_rate_limiter
 
 
+@global_rate_limiter.rate_limit_decorator
 def download_track(
     url,
     main,

--- a/routes/utils/watch/db.py
+++ b/routes/utils/watch/db.py
@@ -2,6 +2,7 @@ import sqlite3
 from pathlib import Path
 import logging
 import time
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -422,7 +423,7 @@ def get_watched_playlist(playlist_spotify_id: str):
 
 
 def update_playlist_snapshot(
-    playlist_spotify_id: str, snapshot_id: str, total_tracks: int
+    playlist_spotify_id: str, snapshot_id: Optional[str], total_tracks: int
 ):
     """Updates the snapshot_id and total_tracks for a watched playlist in playlists.db."""
     try:
@@ -607,7 +608,7 @@ def get_playlist_total_tracks_from_db(playlist_spotify_id: str) -> int:
 
 
 def add_tracks_to_playlist_db(
-    playlist_spotify_id: str, tracks_data: list, snapshot_id: str = None
+    playlist_spotify_id: str, tracks_data: list, snapshot_id: Optional[str] = None
 ):
     """
     Updates existing tracks in the playlist's DB table to mark them as currently present
@@ -873,8 +874,8 @@ def remove_specific_tracks_from_playlist_table(
 def add_single_track_to_playlist_db(
     playlist_spotify_id: str,
     track_item_for_db: dict,
-    snapshot_id: str = None,
-    task_id: str = None,
+    snapshot_id: Optional[str] = None,
+    task_id: Optional[str] = None,
 ):
     """
     Adds or updates a single track in the specified playlist's tracks table in playlists.db.
@@ -1302,7 +1303,7 @@ def get_artist_album_ids_from_db(artist_spotify_id: str):
 def add_or_update_album_for_artist(
     artist_spotify_id: str,
     album_data: dict,
-    task_id: str = None,
+    task_id: Optional[str] = None,
     is_download_complete: bool = False,
 ):
     """Adds or updates an album in the specified artist's albums table in artists.db.

--- a/routes/utils/watch/manager.py
+++ b/routes/utils/watch/manager.py
@@ -4,7 +4,7 @@ import logging
 import json
 import re
 from pathlib import Path
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Optional
 
 from routes.utils.watch.db import (
     get_watched_playlists,
@@ -240,7 +240,9 @@ def _apply_playlist_placeholders(
         return base_dir_fmt, base_track_fmt
 
 
-def has_playlist_changed(playlist_spotify_id: str, current_snapshot_id: str) -> bool:
+def has_playlist_changed(
+    playlist_spotify_id: str, current_snapshot_id: Optional[str]
+) -> bool:
     """
     Check if a playlist has changed by comparing snapshot_id.
     This is much more efficient than fetching all tracks.
@@ -274,7 +276,7 @@ def has_playlist_changed(playlist_spotify_id: str, current_snapshot_id: str) -> 
 
 
 def needs_track_sync(
-    playlist_spotify_id: str, current_snapshot_id: str, api_total_tracks: int
+    playlist_spotify_id: str, current_snapshot_id: Optional[str], api_total_tracks: int
 ) -> tuple[bool, list[str]]:
     """
     Check if tracks need to be synchronized by comparing snapshot_ids and total counts.
@@ -403,7 +405,7 @@ def find_tracks_in_playlist(
     return found_tracks, not_found_tracks
 
 
-def check_watched_playlists(specific_playlist_id: str = None):
+def check_watched_playlists(specific_playlist_id: Optional[str] = None):
     """Checks watched playlists for new tracks and queues downloads.
     If specific_playlist_id is provided, only that playlist is checked.
     Processes at most one batch per run (offset advanced between runs) to avoid rate limits.
@@ -679,7 +681,7 @@ def check_watched_playlists(specific_playlist_id: str = None):
     logger.info("Playlist Watch Manager: Finished checking all watched playlists.")
 
 
-def check_watched_artists(specific_artist_id: str = None):
+def check_watched_artists(specific_artist_id: Optional[str] = None):
     """Checks watched artists for new albums and queues downloads. Processes one page per run to avoid rate limits."""
     logger.info(
         f"Artist Watch Manager: Starting check. Specific artist: {specific_artist_id or 'All'}"

--- a/spotizerr-ui/src/components/RateLimitDisplay.tsx
+++ b/spotizerr-ui/src/components/RateLimitDisplay.tsx
@@ -1,0 +1,149 @@
+import React, { useState, useEffect, useRef } from 'react';
+import authApiClient from '../lib/api-client';
+import { FaTrafficLight, FaTimes } from 'react-icons/fa';
+
+interface RateLimitData {
+  current_requests_per_second: number;
+  max_requests_per_second: number;
+  current_requests_per_window: number;
+  max_requests_per_window: number;
+  window_size_seconds: number;
+}
+
+const RateLimitDisplay: React.FC = () => {
+  const [rateLimit, setRateLimit] = useState<RateLimitData | null>(null);
+  const [showDetails, setShowDetails] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const fetchRateLimit = async () => {
+    try {
+      const response = await authApiClient.get('/rate-limit/current');
+      if (response.status !== 200) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data: RateLimitData = response.data;
+      setRateLimit(data);
+      setError(null);
+    } catch (e: any) {
+      console.error("Failed to fetch rate limit:", e);
+      setError(`Failed to load rate limit: ${e.message}`);
+      setRateLimit(null);
+    }
+  };
+
+  useEffect(() => {
+    fetchRateLimit();
+    const interval = setInterval(fetchRateLimit, 1000); // Refresh every second
+    return () => clearInterval(interval);
+  }, []);
+
+
+  const getIndicatorColor = (current: number, max: number): string => {
+    const percentage = (current / max) * 100;
+    if (percentage >= 90) return 'text-red-500';
+    if (percentage >= 70) return 'text-orange-500';
+    if (percentage >= 50) return 'text-yellow-500';
+    return 'text-gray-800'; // Changed from text-green-500 to text-gray-800
+  };
+
+  const getUsageColor = (current: number, max: number): string => {
+    const percentage = (current / max) * 100;
+    if (percentage >= 90) return 'bg-red-500';
+    if (percentage >= 70) return 'bg-orange-500';
+    if (percentage >= 50) return 'bg-yellow-500';
+    return 'bg-green-500';
+  };
+
+  if (error) {
+    return (
+      <div className="p-2 rounded-full hover:bg-icon-button-hover dark:hover:bg-icon-button-hover-dark cursor-pointer"
+           onClick={() => setShowDetails(!showDetails)}
+           title={`Error: ${error}`}>
+        <FaTrafficLight className="h-6 w-6 text-red-500" />
+      </div>
+    );
+  }
+
+  if (!rateLimit) {
+    return (
+      <div className="p-2 rounded-full hover:bg-icon-button-hover dark:hover:bg-icon-button-hover-dark">
+        <FaTrafficLight className="h-6 w-6 text-gray-500" />
+      </div>
+    );
+  }
+
+  const windowUsage = rateLimit.current_requests_per_window;
+  const windowMax = rateLimit.max_requests_per_window;
+  const windowSize = rateLimit.window_size_seconds;
+  const windowColor = getIndicatorColor(windowUsage, windowMax);
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        className={`p-2 rounded-full hover:bg-icon-button-hover dark:hover:bg-icon-button-hover-dark ${windowColor}`}
+        onClick={() => setShowDetails(!showDetails)}
+        title={`Rate Limit: ${windowUsage}/${windowMax} requests per ${windowSize}s`}
+      >
+        <FaTrafficLight className="h-6 w-6" />
+      </button>
+
+      {showDetails && (
+        <div
+          ref={popupRef}
+          className="absolute top-full right-0 mt-2 w-80 bg-surface dark:bg-surface-dark rounded-xl shadow-2xl border border-border dark:border-border-dark z-50"
+        >
+          <div className="p-0">
+            <div className="flex items-center justify-between p-4 border-b border-border dark:border-border-dark bg-gradient-to-r from-surface to-surface-secondary dark:from-surface-dark dark:to-surface-secondary-dark rounded-t-xl">
+              <h3 className="text-lg font-bold text-content-primary dark:text-content-primary-dark">Rate Limit Consumption</h3>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowDetails(false);
+                }}
+                className="text-content-muted dark:text-content-muted-dark hover:text-content-primary dark:hover:text-content-primary-dark p-2 rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark transition-colors min-h-[44px] flex items-center justify-center"
+                aria-label="Close"
+              >
+                <FaTimes className="text-base" />
+              </button>
+            </div>
+            <div className="p-4 space-y-3">
+              <div>
+                <div className="flex justify-between mb-1">
+                  <span className="text-content-secondary dark:text-content-muted-dark">30 Second Window Usage</span>
+                  <span className="font-medium text-content-primary dark:text-content-primary-dark">{windowUsage} / {windowMax}</span>
+                </div>
+                <div className="w-full bg-surface-muted dark:bg-surface-muted-dark rounded-full h-2">
+                  <div
+                    className={`h-2 rounded-full ${getUsageColor(windowUsage, windowMax)}`}
+                    style={{ width: `${Math.min((windowUsage / windowMax) * 100, 100)}%` }}
+                  ></div>
+                </div>
+              </div>
+              <div>
+                <div className="flex justify-between mb-1">
+                  <span className="text-content-secondary dark:text-content-muted-dark">Per-Second Usage</span>
+                  <span className="font-medium text-content-primary dark:text-content-primary-dark">{rateLimit.current_requests_per_second} / {rateLimit.max_requests_per_second}</span>
+                </div>
+                <div className="w-full bg-surface-muted dark:bg-surface-muted-dark rounded-full h-2">
+                  <div
+                    className={`h-2 rounded-full ${getUsageColor(rateLimit.current_requests_per_second, rateLimit.max_requests_per_second)}`}
+                    style={{ width: `${Math.min((rateLimit.current_requests_per_second / rateLimit.max_requests_per_second) * 100, 100)}%` }}
+                  ></div>
+                </div>
+              </div>
+            </div>
+            <p className="text-xs p-4 pt-3 border-t border-border dark:border-border-dark text-content-muted dark:text-content-muted-dark">
+              External API requests are limited to prevent rate limit errors.
+              If limits are exceeded, requests may be delayed or rejected.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RateLimitDisplay;

--- a/spotizerr-ui/src/routes/root.tsx
+++ b/spotizerr-ui/src/routes/root.tsx
@@ -5,6 +5,7 @@ import { QueueContext } from "@/contexts/queue-context";
 import { Queue } from "@/components/Queue";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { UserMenu } from "@/components/auth/UserMenu";
+import RateLimitDisplay from "@/components/RateLimitDisplay";
 import { useContext, useState, useEffect } from "react";
 import { getTheme, toggleTheme } from "@/lib/theme";
 import { useSettings } from "@/contexts/settings-context";
@@ -106,6 +107,7 @@ function AppLayout() {
             <Link to="/config" className="p-2 rounded-full hover:bg-icon-button-hover dark:hover:bg-icon-button-hover-dark">
               <img src="/settings.svg" alt="Settings" className="w-6 h-6 logo" />
             </Link>
+            <RateLimitDisplay />
             <button onClick={toggleVisibility} className="p-2 rounded-full hover:bg-icon-button-hover dark:hover:bg-icon-button-hover-dark relative">
               <img src="/queue.svg" alt="Queue" className="w-6 h-6 logo" />
               {(totalTasks ?? 0) > 0 && (


### PR DESCRIPTION
### Global Rate Limiter with User Feedback
-   Introduced a global rate limiter that visibly communicates usage and limits to the user—enhancing transparency and usability.
-   Added rate limiting to search requests, expanding protection and performance across different usage patterns.

1. `fix: logging of deezspot` — improvement to logging configuration  
5. `(feat): use rate limiter on search too. Improve rate limiter` — added rate limiting to search  
6. `(feat) introduce a global rate limiter, showing consumption to user` — global rate limiter with user feedback  
2. `(fix): improved types, no more reported issues` — type consistency fixes  
3. `(fix): ensure types of pad_number_width and real_time_multiplier` — stricter type enforcement  
4. `(fix): types` — general typing corrections  

- Debug logging is included and can be activated manually in code, example output:
```
2025-08-25 21:00:34 [WARNING] Rate limit usage: 0/10 req/s, 0/90 req/30s
2025-08-25 21:00:35 [WARNING] Rate limit usage: 1/10 req/s, 1/90 req/30s
2025-08-25 21:00:36 [WARNING] Rate limit usage: 1/10 req/s, 2/90 req/30s
2025-08-25 21:00:37 [WARNING] Rate limit usage: 1/10 req/s, 3/90 req/30s
[...]
2025-08-25 21:01:05 [WARNING] Rate limit usage: 0/10 req/s, 3/90 req/30s
2025-08-25 21:01:06 [WARNING] Rate limit usage: 0/10 req/s, 2/90 req/30s
2025-08-25 21:01:07 [WARNING] Rate limit usage: 0/10 req/s, 1/90 req/30s
```

PS: Sorry for the mix-up with the type improvements, they add noise; won't happen again. 

### Screenshots

> The last one has the correct layout and is the final version.

<img width="397" height="321" alt="image" src="https://github.com/user-attachments/assets/44a54a28-2a56-4d22-bb11-08b60f9e2f66" />
<img width="412" height="347" alt="image" src="https://github.com/user-attachments/assets/75a59e8d-d3a6-43d8-9635-3f3dc5ab5836" />

<img width="460" height="364" alt="image" src="https://github.com/user-attachments/assets/e2b44e15-d260-4abf-83ff-77c6576c19b1" />
